### PR TITLE
Replacing boilerplate with metaprogramming

### DIFF
--- a/DiscordBot/mainMenu.py
+++ b/DiscordBot/mainMenu.py
@@ -3,10 +3,13 @@ from myModal import MyModal
 import uuid
 import time
 
-
 tickets = {}
 
-async def create_completionEmbed(bot, tid):
+def get_drop_down_options(elems : dict[str, str]) -> list[discord.SelectOption]:
+        return [discord.SelectOption(label=l, description=d) for l, d in elems.items()]
+
+# TODO: figure out what bot's type is
+async def create_completionEmbed(bot, tid : int):
     embed = CompletionEmbed(bot, tid)
 
     if 'message_link' in tickets[tid].keys():
@@ -23,12 +26,14 @@ async def create_completionEmbed(bot, tid):
     return embed
 
 class CompletionEmbed(discord.Embed):
-    def __init__(self, bot, tid):
+    def __init__(self, bot, tid : int):
         super().__init__()
         self.tid = tid
         self.bot = bot
         self.title = 'Summary of Report Request'
-        self.description = '"Thank you. We will investigate further. Please expect a response within the next 36 hours."'
+        self.description = \
+                '"Thank you. We will investigate further. \
+                Please expect a response within the next 36 hours."'
         self.add_field(name='Ticket ID', value=tid)
 
 """
@@ -39,14 +44,20 @@ class ReportSelection(discord.ui.View):
         super().__init__()
         self.bot = bot
         self.tid = tid
-    @discord.ui.select(placeholder='Please select reason for reporting this content', options=[
-            discord.SelectOption(label='Harassment', description='description1'),
-            discord.SelectOption(label='Spam', description='description2'),
-            discord.SelectOption(label='Offensive Content', description='description3'),
-            discord.SelectOption(label='Imminent Danger', description='description4'),
-            discord.SelectOption(label='Other', description='description5')
-        ])
-    async def selection_callback(self, interaction:discord.Interaction, selection:discord.ui.Select):
+
+    
+    @discord.ui.select(placeholder='Please select reason for reporting this content', \
+        options=get_drop_down_options({ \
+                'Harassment'         : 'description1', \
+                'Spam'               : 'description2', \
+                'Offensive Content'  : 'description3', \
+                'Imminent Danger'    : 'description4', \
+                'Other'              : 'description5'
+        }) \
+    )
+    async def selection_callback(self, \
+        interaction : discord.Interaction, \
+        selection : discord.ui.Select):
         # await interaction.response.send_message(f'You chose {selection.values[0]}',  ephemeral=True)
 
         tickets[self.tid] = {'reason': selection.values[0]}
@@ -87,13 +98,15 @@ class HarassmentSelection(discord.ui.View):
         self.tid = tid
         self.bot = bot
 
-    @discord.ui.select(placeholder='Select Type', options=[
-            discord.SelectOption(label='Sextortion', description='description1'),
-            discord.SelectOption(label='Hate Speech', description='description2'),
-            discord.SelectOption(label='Encouraging Self-harm', description='description3'),
-            discord.SelectOption(label='Threats', description='description4'),
-            discord.SelectOption(label='Other', description='description5')
-        ])
+    @discord.ui.select(placeholder='Select Type',
+         options=get_drop_down_options({
+            'Sextortion'                : 'description1',
+            'Hate Speech'               : 'description2',
+            'Encouraging Self-harm'     : 'description3',
+            'Threats'                   : 'description4',
+            'Other'                     : 'description5'
+        })
+    )
     async def selection_callback(self, interaction:discord.Interaction, selection:discord.ui.Select):
         tickets[self.tid]['harassment_type'] = selection.values[0]
 

--- a/DiscordBot/mainMenu.py
+++ b/DiscordBot/mainMenu.py
@@ -300,7 +300,6 @@ class MainMenuEmbed(discord.Embed):
         self.add_field(name="Help", value="Click this to receive more information", inline=False)
         self.add_field(name="Talk to Moderator", value="Click this to request a private conversation with a moderator", inline=False)
 
-
 class MainMenuButtons(discord.ui.View):
     def __init__(self, bot, mod_channel):
         super().__init__()

--- a/DiscordBot/mainMenu.py
+++ b/DiscordBot/mainMenu.py
@@ -213,7 +213,7 @@ async def my_images_callback(bot, tid : int, interaction : Interaction, button :
                 view=KnowImageSelection(bot, tid), ephemeral=True)
 
 async def others_images_callback(bot, tid : int, interaction : Interaction, button : Button):
-        tickets[self.tid]['shared_explicit'] = 'No'
+        tickets[tid]['shared_explicit'] = 'No'
         # await interaction.response.send_message(embed=await create_completionEmbed(self.bot, self.tid), ephemeral=True)
         await interaction.response.send_message('You responded: No.',  ephemeral=True)
         await send_completionEmbed(interaction, bot, tid)
@@ -305,7 +305,7 @@ Embed to redirect to takeitdown or other external image removal resources
 """
 class ImageRemovalEmbed(discord.Embed):
     def __init__(self):
-        super().__init__(title='Removal/Preventation Resources', url='https://takeitdown.ncmec.org/')
+        super().__init__(title='Removal/Prevention Resources', url='https://takeitdown.ncmec.org/')
         self.add_field(name="Please click on the link above.", value="These instructions will help get your image removed and stop their spread", inline=False)
 class MainMenuEmbed(discord.Embed):
     def __init__(self):


### PR DESCRIPTION
Purpose: This PR is dedicated to reducing the amount of boilerplate in mainMenu.py, thus allowing us to focus more on the ideas level than on implementation.

Changes:
--`get_drop_down_options`: a small method that's just a list comprehension, allowing decorators for selection objects to have less fluff around the actual contents.
--(the big one): Replacing OOP bloat with metaprogramming. `BinaryOption` generates a class with the given options, which is then instantiated and returned by various methods (these factory methods replace the constructors of the classes before). Class instantiation involves passing handler callables, so the behavior of a class on each option can be customized (I just used the method bodies from the classes that existed before).

I have tried to exhaustively search the possible inputs to ensure that there are no bugs resulting from merge conflict resolution, but some may remain. Please let me know if you find one.